### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Electronic Sweet Peas
 maintainer=Electronic Sweet Peas <info@sweetpeas.se>
 sentence=Socket library for CC3000 based products
 paragraph=Contains both a low level socket API as well as higher level methods for connecting and sending data to cloud services.
+category=Communication
 url=https://github.com/Sweet-Peas/SP3000
 architectures=avr


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library SP3000 is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6 and 1.6.7. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
